### PR TITLE
removing unneeded Data::Dumper code

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,6 +5,6 @@ WriteMakefile(
     'NAME'	=> 'XML::Generator::PerlData',
     'VERSION_FROM' => 'PerlData.pm', # finds $VERSION,
     'PREREQ_PM' => {
-                     'XML::SAX::Base' => 1.02
-                   }
+        'XML::SAX::Base' => 1.02
+    }
 );

--- a/PerlData.pm
+++ b/PerlData.pm
@@ -3,7 +3,7 @@ package XML::Generator::PerlData;
 use strict;
 use XML::SAX::Base;
 use vars qw($VERSION @ISA $NS_XMLNS $NS_XML);
-use Data::Dumper;
+
 # some globals
 $VERSION = '0.91';
 @ISA = qw( XML::SAX::Base );
@@ -109,7 +109,6 @@ sub init {
         %skippers = map { $_, 1} @{$args{skipelements}}
     }
 
-    #warn "SKIPPPERS " . Dumper( \%args );
     $self->{Skipelements} = \%skippers;
 
 }

--- a/t/10arry_keymap.t
+++ b/t/10arry_keymap.t
@@ -35,7 +35,6 @@ ok( $stack[13]->{LocalName} eq 'document' );
 
 package SAXDumper;
 use strict;
-use Data::Dumper;
 
 use vars qw($AUTOLOAD);
     

--- a/t/12nstest1.t
+++ b/t/12nstest1.t
@@ -95,7 +95,6 @@ sub new {
 
 package SAXDumper;
 use strict;
-use Data::Dumper;
 
 use vars qw($AUTOLOAD);
     

--- a/t/13nstest2.t
+++ b/t/13nstest2.t
@@ -73,7 +73,6 @@ my %sh2 = (foo  => 'foobie',
 
 package SAXDumper;
 use strict;
-use Data::Dumper;
 
 use vars qw($AUTOLOAD);
     

--- a/t/14processing_instruction.t
+++ b/t/14processing_instruction.t
@@ -69,7 +69,6 @@ my %sh2 = (foo  => 'foobie',
 
 package SAXDumper;
 use strict;
-use Data::Dumper;
 
 use vars qw($AUTOLOAD);
     


### PR DESCRIPTION
Hey ubu!

Several bits of this code load Data::Dumper, even though it's not listed in the Makefile.PL. Aside from the extra dependency, tests only pass because Data::Dumper is core :D 

This patch removes all calls to Data::Dumper. There is not a single call to "Dumper" in the code now (except for SAXDumper on the tests, but that's another thing entirely)
